### PR TITLE
Cleanup unmaintainable parallel logic with workers

### DIFF
--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -232,8 +232,7 @@ namespace System.Threading.Tasks
                 if (OperatingSystem.IsBrowser() ||
                     // This is more efficient for a large number of actions, or for enforcing MaxDegreeOfParallelism:
                     (actionsCopy.Length > SMALL_ACTIONCOUNT_LIMIT) ||
-                    (parallelOptions.MaxDegreeOfParallelism != -1 &&
-                     parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length)
+                    (parallelOptions.MaxDegreeOfParallelism != -1 && parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length)
                    )
                 {
                     // Used to hold any exceptions encountered during action processing
@@ -266,8 +265,7 @@ namespace System.Threading.Tasks
                                     }
                                     catch (Exception e)
                                     {
-                                        LazyInitializer.EnsureInitialized(ref exceptionQ,
-                                            () => { return new ConcurrentQueue<Exception>(); });
+                                        LazyInitializer.EnsureInitialized(ref exceptionQ, () => { return new ConcurrentQueue<Exception>(); });
                                         exceptionQ.Enqueue(e);
                                     }
 
@@ -283,8 +281,7 @@ namespace System.Threading.Tasks
                     }
                     catch (Exception e)
                     {
-                        LazyInitializer.EnsureInitialized(ref exceptionQ,
-                            () => { return new ConcurrentQueue<Exception>(); });
+                        LazyInitializer.EnsureInitialized(ref exceptionQ, () => { return new ConcurrentQueue<Exception>(); });
 
                         // Since we're consuming all action exceptions, there are very few reasons that
                         // we would see an exception here.  Two that come to mind:
@@ -311,8 +308,7 @@ namespace System.Threading.Tasks
                     // If we have encountered any exceptions, then throw.
                     if ((exceptionQ != null) && (!exceptionQ.IsEmpty))
                     {
-                        ThrowSingleCancellationExceptionOrOtherException(exceptionQ, parallelOptions.CancellationToken,
-                            new AggregateException(exceptionQ));
+                        ThrowSingleCancellationExceptionOrOtherException(exceptionQ, parallelOptions.CancellationToken, new AggregateException(exceptionQ));
                     }
                 }
                 else // This is more efficient for a small number of actions and no DOP support:
@@ -326,9 +322,7 @@ namespace System.Threading.Tasks
                     // Invoke all actions as tasks.  Queue N-1 of them, and run 1 synchronously.
                     for (int i = 1; i < tasks.Length; i++)
                     {
-                        tasks[i] = Task.Factory.StartNew(actionsCopy[i], parallelOptions.CancellationToken,
-                            TaskCreationOptions.None,
-                            parallelOptions.EffectiveTaskScheduler);
+                        tasks[i] = Task.Factory.StartNew(actionsCopy[i], parallelOptions.CancellationToken, TaskCreationOptions.None, parallelOptions.EffectiveTaskScheduler);
                     }
 
                     tasks[0] = new Task(actionsCopy[0], parallelOptions.CancellationToken, TaskCreationOptions.None);
@@ -346,8 +340,7 @@ namespace System.Threading.Tasks
                     catch (AggregateException aggExp)
                     {
                         // see if we can combine it into a single OCE. If not propagate the original exception
-                        ThrowSingleCancellationExceptionOrOtherException(aggExp.InnerExceptions,
-                            parallelOptions.CancellationToken, aggExp);
+                        ThrowSingleCancellationExceptionOrOtherException(aggExp.InnerExceptions, parallelOptions.CancellationToken, aggExp);
                     }
                 }
             }
@@ -428,8 +421,7 @@ namespace System.Threading.Tasks
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range:
         /// [fromInclusive, toExclusive).  It is provided with the iteration count (an Int32) as a parameter.
         /// </remarks>
-        public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions,
-            Action<int> body)
+        public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> body)
         {
             return For<int>(fromInclusive, toExclusive, parallelOptions, body);
         }
@@ -461,19 +453,14 @@ namespace System.Threading.Tasks
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range:
         /// [fromInclusive, toExclusive).  It is provided with the iteration count (an Int64) as a parameter.
         /// </remarks>
-        public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions,
-            Action<long> body)
+        public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions, Action<long> body)
         {
             return For<long>(fromInclusive, toExclusive, parallelOptions, body);
         }
 
-        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive,
-            ParallelOptions parallelOptions, Action<TIndex> body)
+        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive, ParallelOptions parallelOptions, Action<TIndex> body)
             where TIndex : INumber<TIndex>
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
-
             IWorkerBodyFactory<TIndex> workerBodyFactory = new WorkerWithSimpleBodyFactory<TIndex>(body);
             return ForWorkerOrchestrator(fromInclusive, toExclusive, parallelOptions, workerBodyFactory);
         }
@@ -575,8 +562,7 @@ namespace System.Threading.Tasks
         /// and a <see cref="System.Threading.Tasks.ParallelLoopState">ParallelLoopState</see> instance that may be
         /// used to break out of the loop prematurely.
         /// </remarks>
-        public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions,
-            Action<int, ParallelLoopState> body)
+        public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int, ParallelLoopState> body)
         {
             return For<int>(fromInclusive, toExclusive, parallelOptions, body);
         }
@@ -610,19 +596,14 @@ namespace System.Threading.Tasks
         /// and a <see cref="System.Threading.Tasks.ParallelLoopState">ParallelLoopState</see> instance that may be
         /// used to break out of the loop prematurely.
         /// </remarks>
-        public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions,
-            Action<long, ParallelLoopState> body)
+        public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions, Action<long, ParallelLoopState> body)
         {
             return For<long>(fromInclusive, toExclusive, parallelOptions, body);
         }
 
-        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive,
-            ParallelOptions parallelOptions, Action<TIndex, ParallelLoopState> body)
+        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive, ParallelOptions parallelOptions, Action<TIndex, ParallelLoopState> body)
             where TIndex : INumber<TIndex>
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
-
             IWorkerBodyFactory<TIndex> workerBodyFactory = new WorkerWithStateFactory<TIndex, TIndex>(body);
             return ForWorkerOrchestrator(fromInclusive, toExclusive, parallelOptions, workerBodyFactory);
         }
@@ -671,8 +652,7 @@ namespace System.Threading.Tasks
             Func<int, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
-            return For<int, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body,
-                localFinally);
+            return For<int, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body, localFinally);
         }
 
         /// <summary>
@@ -719,8 +699,7 @@ namespace System.Threading.Tasks
             Func<long, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
-            return For<long, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body,
-                localFinally);
+            return For<long, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body, localFinally);
         }
 
         /// <summary>
@@ -846,11 +825,6 @@ namespace System.Threading.Tasks
             Action<TLocal> localFinally)
             where TIndex : INumber<TIndex>
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
-
             IWorkerBodyFactory<TIndex> workerBodyFactory = new WorkerWithLocalFactory<TIndex, TIndex, TLocal>(body, localInit, localFinally);
             return ForWorkerOrchestrator(fromInclusive, toExclusive, parallelOptions, workerBodyFactory);
         }
@@ -875,8 +849,8 @@ namespace System.Threading.Tasks
             ParallelOptions parallelOptions,
             IWorkerBodyFactory<TIndex> workerBodyFactory) where TIndex : INumber<TIndex>
         {
-            Debug.Assert(typeof(TIndex) == typeof(int) || typeof(TIndex) == typeof(long),
-                "only long and int index types supported in TIndex");
+            Debug.Assert(typeof(TIndex) == typeof(int) || typeof(TIndex) == typeof(long), "only long and int index types supported in TIndex");
+            ArgumentNullException.ThrowIfNull(parallelOptions);
 
             // Instantiate our result.  Specifics will be filled in later.
             ParallelLoopResult result = default;
@@ -888,6 +862,13 @@ namespace System.Threading.Tasks
                 return result;
             }
 
+            // initialize ranges with passed in loop arguments and expected number of workers
+            int numExpectedWorkers = (parallelOptions.EffectiveMaxConcurrencyLevel == -1)
+                ? Environment.ProcessorCount
+                : parallelOptions.EffectiveMaxConcurrencyLevel;
+            RangeManager rangeManager = new RangeManager(long.CreateChecked(fromInclusive),
+                long.CreateChecked(toExclusive), 1, numExpectedWorkers);
+
             // For all loops we need a shared flag even though we don't have a body with state,
             // because the shared flag contains the exceptional bool, which triggers other workers
             // to exit their loops if one worker catches an exception
@@ -897,20 +878,11 @@ namespace System.Threading.Tasks
             parallelOptions.CancellationToken.ThrowIfCancellationRequested();
 
             // Keep track of any cancellations
-            Box<OperationCanceledException> oce =
-                RegisterCallbackForLoopTermination(parallelOptions, sharedPStateFlags, out var ctr);
+            Box<OperationCanceledException> oce = RegisterCallbackForLoopTermination(parallelOptions, sharedPStateFlags, out CancellationTokenRegistration ctr);
 
-            const ParallelEtwProvider.ForkJoinOperationType OperationType =
-                ParallelEtwProvider.ForkJoinOperationType.ParallelFor;
+            const ParallelEtwProvider.ForkJoinOperationType OperationType = ParallelEtwProvider.ForkJoinOperationType.ParallelFor;
 
             int forkJoinContextID = LogEtwEventParallelLoopBegin(OperationType, fromInclusive, toExclusive);
-
-            // initialize ranges with passed in loop arguments and expected number of workers
-            int numExpectedWorkers = (parallelOptions.EffectiveMaxConcurrencyLevel == -1)
-                ? Environment.ProcessorCount
-                : parallelOptions.EffectiveMaxConcurrencyLevel;
-            RangeManager rangeManager = new RangeManager(long.CreateChecked(fromInclusive),
-                long.CreateChecked(toExclusive), 1, numExpectedWorkers);
 
             try
             {
@@ -934,8 +906,7 @@ namespace System.Threading.Tasks
             catch (AggregateException aggExp)
             {
                 // If we have many cancellation exceptions all caused by the specified user cancel control, then throw only one OCE:
-                ThrowSingleCancellationExceptionOrOtherException(aggExp.InnerExceptions,
-                    parallelOptions.CancellationToken, aggExp);
+                ThrowSingleCancellationExceptionOrOtherException(aggExp.InnerExceptions, parallelOptions.CancellationToken, aggExp);
             }
             finally
             {
@@ -1052,10 +1023,8 @@ namespace System.Threading.Tasks
                 do
                 {
                     for (TIndex j = nFromInclusiveLocal;
-                         j < nToExclusiveLocal &&
-                         (SharedPStateFlags.LoopStateFlags ==
-                          ParallelLoopStateFlags.ParallelLoopStateNone // fast path check as SEL() doesn't inline
-                          || !SharedPStateFlags.ShouldExitLoop(j));
+                         j < nToExclusiveLocal && (SharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone // fast path check as SEL() doesn't inline
+                                                   || !SharedPStateFlags.ShouldExitLoop(j));
                          j += TIndex.One)
                     {
                         if (workerBody is IWorkerBodyWithIndex<TIndex, TIndex> workerBodyWithIndex)
@@ -1081,8 +1050,7 @@ namespace System.Threading.Tasks
             }
 
             public static Worker<RangeWorker, TIndex> CreateWorker(
-                int forkJoinContextId, ParallelLoopStateFlags sharedPStateFlags, RangeManager source,
-                IWorkerBodyFactory<TIndex> workerBodyFactory)
+                int forkJoinContextId, ParallelLoopStateFlags sharedPStateFlags, RangeManager source, IWorkerBodyFactory<TIndex> workerBodyFactory)
                 => new ForWorker<TIndex>(forkJoinContextId, sharedPStateFlags, source, workerBodyFactory);
         }
 
@@ -1152,12 +1120,12 @@ namespace System.Threading.Tasks
             {
                 int from = array.GetLowerBound(0);
                 int to = array.GetUpperBound(0) + 1;
-                return For(from, to, (i) => body(array[i]));
+                return For(from, to, parallelOptions, (i) => body(array[i]));
             }
 
             if (source is IList<TSource> list)
             {
-                return For(0, list.Count, (i) => body(list[i]));
+                return For(0, list.Count, parallelOptions, (i) => body(list[i]));
             }
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithSimpleBodyFactory<TSource>(body);
@@ -1232,12 +1200,12 @@ namespace System.Threading.Tasks
             {
                 int from = array.GetLowerBound(0);
                 int to = array.GetUpperBound(0) + 1;
-                return For(from, to, (i, state) => body(array[i], state));
+                return For(from, to, parallelOptions, (i, state) => body(array[i], state));
             }
 
             if (source is IList<TSource> list)
             {
-                return For(0, list.Count, (i, state) => body(list[i], state));
+                return For(0, list.Count, parallelOptions, (i, state) => body(list[i], state));
             }
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithStateFactory<TSource, long>(body);
@@ -1312,16 +1280,15 @@ namespace System.Threading.Tasks
             {
                 int from = array.GetLowerBound(0);
                 int to = array.GetUpperBound(0) + 1;
-                return For(from, to, (i, state) => body(array[i], state, i));
+                return For(from, to, parallelOptions, (i, state) => body(array[i], state, i));
             }
 
             if (source is IList<TSource> list)
             {
-                return For(0, list.Count, (i, state) => body(list[i], state, i));
+                return For(0, list.Count, parallelOptions, (i, state) => body(list[i], state, i));
             }
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithStateAndIndexFactory<TSource, long>(body);
-
             return PartitionerForEachWorker(Partitioner.Create(source), parallelOptions, workerBodyFactory);
         }
 
@@ -1438,12 +1405,12 @@ namespace System.Threading.Tasks
             {
                 int from = array.GetLowerBound(0);
                 int to = array.GetUpperBound(0) + 1;
-                return For(from, to, localInit, (i, state, local) => body(array[i], state, local), localFinally);
+                return For(from, to, parallelOptions, localInit, (i, state, local) => body(array[i], state, local), localFinally);
             }
 
             if (source is IList<TSource> list)
             {
-                return For(0, list.Count, localInit, (i, state, local) => body(list[i], state, local), localFinally);
+                return For(0, list.Count, parallelOptions, localInit, (i, state, local) => body(list[i], state, local), localFinally);
             }
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithLocalFactory<TSource, long, TLocal>(body, localInit, localFinally);
@@ -1562,12 +1529,12 @@ namespace System.Threading.Tasks
             {
                 int from = array.GetLowerBound(0);
                 int to = array.GetUpperBound(0) + 1;
-                return For(from, to, localInit, (i, state, local) => body(array[i], state, i, local), localFinally);
+                return For(from, to, parallelOptions, localInit, (i, state, local) => body(array[i], state, i, local), localFinally);
             }
 
             if (source is IList<TSource> list)
             {
-                return For(0, list.Count, localInit, (i, state, local) => body(list[i], state, i, local), localFinally);
+                return For(0, list.Count, parallelOptions, localInit, (i, state, local) => body(list[i], state, i, local), localFinally);
             }
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithEveryThingFactory<TSource, long, TLocal>(body, localInit, localFinally);
@@ -1616,9 +1583,7 @@ namespace System.Threading.Tasks
         /// Partitioner.  It is provided with the current element as a parameter.
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            Partitioner<TSource> source,
-            Action<TSource> body)
+        public static ParallelLoopResult ForEach<TSource>(Partitioner<TSource> source, Action<TSource> body)
         {
             return ForEach(source, s_defaultParallelOptions, body);
         }
@@ -1666,9 +1631,7 @@ namespace System.Threading.Tasks
         /// used to break out of the loop prematurely.
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            Partitioner<TSource> source,
-            Action<TSource, ParallelLoopState> body)
+        public static ParallelLoopResult ForEach<TSource>(Partitioner<TSource> source, Action<TSource, ParallelLoopState> body)
         {
             return ForEach(source, s_defaultParallelOptions, body);
         }
@@ -1719,9 +1682,7 @@ namespace System.Threading.Tasks
         /// used to break out of the loop prematurely, and the current element's index (an Int64).
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            OrderablePartitioner<TSource> source,
-            Action<TSource, ParallelLoopState, long> body)
+        public static ParallelLoopResult ForEach<TSource>(OrderablePartitioner<TSource> source, Action<TSource, ParallelLoopState, long> body)
         {
             return ForEach(source, s_defaultParallelOptions, body);
         }
@@ -1788,10 +1749,7 @@ namespace System.Threading.Tasks
         /// </para>
         /// </remarks>
         public static ParallelLoopResult ForEach<TSource, TLocal>(
-            Partitioner<TSource> source,
-            Func<TLocal> localInit,
-            Func<TSource, ParallelLoopState, TLocal, TLocal> body,
-            Action<TLocal> localFinally)
+            Partitioner<TSource> source, Func<TLocal> localInit, Func<TSource, ParallelLoopState, TLocal, TLocal> body, Action<TLocal> localFinally)
         {
             return ForEach(source, s_defaultParallelOptions, localInit, body, localFinally);
         }
@@ -1861,10 +1819,7 @@ namespace System.Threading.Tasks
         /// </para>
         /// </remarks>
         public static ParallelLoopResult ForEach<TSource, TLocal>(
-            OrderablePartitioner<TSource> source,
-            Func<TLocal> localInit,
-            Func<TSource, ParallelLoopState, long, TLocal, TLocal> body,
-            Action<TLocal> localFinally)
+            OrderablePartitioner<TSource> source, Func<TLocal> localInit, Func<TSource, ParallelLoopState, long, TLocal, TLocal> body, Action<TLocal> localFinally)
         {
             return ForEach(source, s_defaultParallelOptions, localInit, body, localFinally);
         }
@@ -1921,14 +1876,10 @@ namespace System.Threading.Tasks
         /// Partitioner.  It is provided with the current element as a parameter.
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            Partitioner<TSource> source,
-            ParallelOptions parallelOptions,
-            Action<TSource> body)
+        public static ParallelLoopResult ForEach<TSource>(Partitioner<TSource> source, ParallelOptions parallelOptions, Action<TSource> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithSimpleBodyFactory<TSource>(body);
             return PartitionerForEachWorker(source, parallelOptions, workerBodyFactory);
@@ -1988,14 +1939,10 @@ namespace System.Threading.Tasks
         /// used to break out of the loop prematurely.
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            Partitioner<TSource> source,
-            ParallelOptions parallelOptions,
-            Action<TSource, ParallelLoopState> body)
+        public static ParallelLoopResult ForEach<TSource>(Partitioner<TSource> source, ParallelOptions parallelOptions, Action<TSource, ParallelLoopState> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithStateFactory<TSource, long>(body);
             return PartitionerForEachWorker(source, parallelOptions, workerBodyFactory);
@@ -2058,14 +2005,10 @@ namespace System.Threading.Tasks
         /// used to break out of the loop prematurely, and the current element's index (an Int64).
         /// </para>
         /// </remarks>
-        public static ParallelLoopResult ForEach<TSource>(
-            OrderablePartitioner<TSource> source,
-            ParallelOptions parallelOptions,
-            Action<TSource, ParallelLoopState, long> body)
+        public static ParallelLoopResult ForEach<TSource>(OrderablePartitioner<TSource> source, ParallelOptions parallelOptions, Action<TSource, ParallelLoopState, long> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
 
             if (!source.KeysNormalized)
             {
@@ -2157,9 +2100,6 @@ namespace System.Threading.Tasks
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
 
             IWorkerBodyFactory<TSource> workerBodyFactory = new WorkerWithLocalFactory<TSource, long, TLocal>(body, localInit, localFinally);
             return PartitionerForEachWorker(source, parallelOptions, workerBodyFactory);
@@ -2249,9 +2189,6 @@ namespace System.Threading.Tasks
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
 
             if (!source.KeysNormalized)
             {
@@ -2265,25 +2202,57 @@ namespace System.Threading.Tasks
         #endregion
 
         // Main worker method for Parallel.ForEach() calls w/ Partitioners.
-        private static ParallelLoopResult PartitionerForEachWorker<TSource>(
-            Partitioner<TSource> source, // Might be OrderablePartitioner
-            ParallelOptions parallelOptions,
-            IWorkerBodyFactory<TSource> workerBodyFactory)
+        private static ParallelLoopResult PartitionerForEachWorker<TValue>(Partitioner<TValue> source, ParallelOptions parallelOptions, IWorkerBodyFactory<TValue> workerBodyFactory)
         {
-            OrderablePartitioner<TSource>? orderedSource = source as OrderablePartitioner<TSource>;
+            if (source is OrderablePartitioner<TValue> orderedSource)
+            {
+                return PartitionerForEachWorker(orderedSource, parallelOptions, workerBodyFactory);
+            }
 
             if (!source.SupportsDynamicPartitions)
             {
                 throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerNotDynamic);
             }
 
+            IEnumerable<TValue>? partitionerSource = source.GetDynamicPartitions();
+            if (partitionerSource == null)
+            {
+                throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerReturnedNull);
+            }
+
+            return PartitionerForEachWorkerCore<IEnumerable<TValue>, IEnumerator, TValue, PartitionerForeachWorker<TValue>>(
+                partitionerSource, parallelOptions, workerBodyFactory);
+        }
+
+        // Main worker method for Parallel.ForEach() calls w/ Partitioners.
+        private static ParallelLoopResult PartitionerForEachWorker<TValue>(OrderablePartitioner<TValue> orderedSource, ParallelOptions parallelOptions, IWorkerBodyFactory<TValue> workerBodyFactory)
+        {
+            if (!orderedSource.SupportsDynamicPartitions)
+            {
+                throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerNotDynamic);
+            }
+
+            IEnumerable<KeyValuePair<long, TValue>>? orderablePartitionerSource = orderedSource.GetOrderableDynamicPartitions();
+            if (orderablePartitionerSource == null)
+            {
+                throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerReturnedNull);
+            }
+
+            return PartitionerForEachWorkerCore<IEnumerable<KeyValuePair<long, TValue>>, IEnumerator, TValue, OrderablePartitionerForeachWorker<TValue>>(
+                orderablePartitionerSource, parallelOptions, workerBodyFactory);
+        }
+
+        // Main worker method for Parallel.ForEach() calls w/ Partitioners.
+        private static ParallelLoopResult PartitionerForEachWorkerCore<TSource, TInput, TValue, TWorker>(TSource source, ParallelOptions parallelOptions, IWorkerBodyFactory<TValue> workerBodyFactory)
+            where TWorker: IWorkerFactory<TSource, TInput, TValue>
+        {
             // Instantiate our result.  Specifics will be filled in later.
             ParallelLoopResult result = default;
 
             // For all loops we need a shared flag even though we don't have a body with state,
             // because the shared flag contains the exceptional bool, which triggers other workers
             // to exit their loops if one worker catches an exception
-            ParallelLoopStateFlags sharedPStateFlags = new ParallelLoopStateFlags64();
+            ParallelLoopStateFlags sharedPStateFlags = ParallelLoopStateFlags.Create<long>();
 
             // Before getting started, do a quick peek to see if we have been canceled already
             parallelOptions.CancellationToken.ThrowIfCancellationRequested();
@@ -2295,43 +2264,12 @@ namespace System.Threading.Tasks
 
             int forkJoinContextID = LogEtwEventParallelLoopBegin(OperationType, 0, 0);
 
-            // Get our dynamic partitioner -- depends on whether source is castable to OrderablePartitioner
-            // Also, do some error checking.
-            IEnumerable<TSource>? partitionerSource = null;
-            IEnumerable<KeyValuePair<long, TSource>>? orderablePartitionerSource = null;
-            if (orderedSource != null)
-            {
-                orderablePartitionerSource = orderedSource.GetOrderableDynamicPartitions();
-                if (orderablePartitionerSource == null)
-                {
-                    throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerReturnedNull);
-                }
-            }
-            else
-            {
-                partitionerSource = source.GetDynamicPartitions();
-                if (partitionerSource == null)
-                {
-                    throw new InvalidOperationException(SR.Parallel_ForEach_PartitionerReturnedNull);
-                }
-            }
-
             try
             {
                 try
                 {
-                    TaskReplicator.ReplicatableUserAction<IEnumerator> worker;
-                    if (orderablePartitionerSource != null)
-                    {
-                        worker = OrderablePartitionerForeachWorker<TSource>.CreateWorker(
-                            forkJoinContextID, sharedPStateFlags, orderablePartitionerSource, workerBodyFactory).Work;
-                    }
-                    else
-                    {
-                        worker = PartitionerForeachWorker<TSource>.CreateWorker(
-                            forkJoinContextID, sharedPStateFlags, partitionerSource!, workerBodyFactory).Work;
-                    }
-
+                    TaskReplicator.ReplicatableUserAction<TInput> worker =
+                        TWorker.CreateWorker(forkJoinContextID, sharedPStateFlags, source, workerBodyFactory).Work;
                     TaskReplicator.Run(worker, parallelOptions, stopOnFirstFailure: true);
                 }
                 finally
@@ -2354,17 +2292,7 @@ namespace System.Threading.Tasks
             {
                 SetLoopResultEndState(sharedPStateFlags, ref result);
 
-                //dispose the partitioner source if it implements IDisposable
-                IDisposable? d;
-                if (orderablePartitionerSource != null)
-                {
-                    d = orderablePartitionerSource as IDisposable;
-                }
-                else
-                {
-                    d = partitionerSource as IDisposable;
-                }
-
+                IDisposable? d = source as IDisposable;
                 d?.Dispose();
 
                 // ETW event for Parallel For End
@@ -2462,8 +2390,7 @@ namespace System.Threading.Tasks
                 int forkJoinContextId, ParallelLoopStateFlags sharedPStateFlags,
                 IEnumerable<KeyValuePair<long, TValue>> source,
                 IWorkerBodyFactory<TValue> workerBodyFactory) =>
-                new OrderablePartitionerForeachWorker<TValue>(forkJoinContextId, sharedPStateFlags, source,
-                    workerBodyFactory);
+                new OrderablePartitionerForeachWorker<TValue>(forkJoinContextId, sharedPStateFlags, source, workerBodyFactory);
         }
 
         private sealed class PartitionerForeachWorker<TValue>
@@ -2827,6 +2754,8 @@ namespace System.Threading.Tasks
 
             public WorkerWithSimpleBodyFactory(Action<TValue> body)
             {
+                ArgumentNullException.ThrowIfNull(body);
+
                 _body = body;
             }
 
@@ -2840,6 +2769,8 @@ namespace System.Threading.Tasks
 
             public WorkerWithStateFactory(Action<TValue, ParallelLoopState> bodyWithState)
             {
+                ArgumentNullException.ThrowIfNull(bodyWithState);
+
                 _bodyWithState = bodyWithState;
             }
 
@@ -2853,6 +2784,8 @@ namespace System.Threading.Tasks
 
             public WorkerWithStateAndIndexFactory(Action<TValue, ParallelLoopState, TIndex> bodyWithStateAndIndex)
             {
+                ArgumentNullException.ThrowIfNull(bodyWithStateAndIndex);
+
                 _bodyWithStateAndIndex = bodyWithStateAndIndex;
             }
 
@@ -2869,6 +2802,10 @@ namespace System.Threading.Tasks
 
             public WorkerWithLocalFactory(Func<TValue, ParallelLoopState, TLocal, TLocal> bodyWithLocal, Func<TLocal> localInit, Action<TLocal>? localFinally)
             {
+                ArgumentNullException.ThrowIfNull(localInit);
+                ArgumentNullException.ThrowIfNull(bodyWithLocal);
+                ArgumentNullException.ThrowIfNull(localFinally);
+
                 _bodyWithLocal = bodyWithLocal;
                 _localInit = localInit;
                 _localFinally = localFinally;
@@ -2886,6 +2823,10 @@ namespace System.Threading.Tasks
 
             public WorkerWithEveryThingFactory(Func<TValue, ParallelLoopState, TIndex, TLocal, TLocal> bodyWithLocal, Func<TLocal> localInit, Action<TLocal>? localFinally)
             {
+                ArgumentNullException.ThrowIfNull(localInit);
+                ArgumentNullException.ThrowIfNull(bodyWithLocal);
+                ArgumentNullException.ThrowIfNull(localFinally);
+
                 _bodyWithLocal = bodyWithLocal;
                 _localInit = localInit;
                 _localFinally = localFinally;

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -14,14 +14,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.ExceptionServices;
+using System.Runtime.CompilerServices;
 
 namespace System.Threading.Tasks
 {
-    internal sealed class Box<T> where T: class
-    {
-        public T? Value { get; set; }
-    }
-
     /// <summary>
     /// Stores options that configure the operation of methods on the
     /// <see cref="System.Threading.Tasks.Parallel">Parallel</see> class.
@@ -866,7 +862,7 @@ namespace System.Threading.Tasks
             parallelOptions.CancellationToken.ThrowIfCancellationRequested();
 
             // Keep track of any cancellations
-            Box<OperationCanceledException> oce = ParallelHelpers.RegisterCallbackForLoopTermination(parallelOptions, sharedPStateFlags, out CancellationTokenRegistration ctr);
+            StrongBox<OperationCanceledException> oce = ParallelHelpers.RegisterCallbackForLoopTermination(parallelOptions, sharedPStateFlags, out CancellationTokenRegistration ctr);
 
             int forkJoinContextID = ParallelHelpers.LogEtwEventParallelLoopBegin(
                 operationType, TWorker.GetStartIndex(source), TWorker.GetEndIndex(source));
@@ -2647,10 +2643,10 @@ namespace System.Threading.Tasks
 
     internal static class ParallelHelpers
     {
-        public static Box<OperationCanceledException> RegisterCallbackForLoopTermination(ParallelOptions parallelOptions,
+        public static StrongBox<OperationCanceledException> RegisterCallbackForLoopTermination(ParallelOptions parallelOptions,
             ParallelLoopStateFlags sharedPStateFlags, out CancellationTokenRegistration ctr)
         {
-            Box<OperationCanceledException> oce = new() { Value = null };
+            StrongBox<OperationCanceledException> oce = new();
 
             // if cancellation is enabled, we need to register a callback to stop the loop when it gets signaled
             ctr = (!parallelOptions.CancellationToken.CanBeCanceled)

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -371,11 +371,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(int fromInclusive, int toExclusive, Action<int> body)
         {
-            ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<int, object>(
-                fromInclusive, toExclusive,
-                s_defaultParallelOptions,
-                body, null, null, null, null);
+            return For<int>(fromInclusive, toExclusive, s_defaultParallelOptions, body);
         }
 
         /// <summary>
@@ -396,10 +392,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(long fromInclusive, long toExclusive, Action<long> body)
         {
-            ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<long, object>(
-                fromInclusive, toExclusive, s_defaultParallelOptions,
-                body, null, null, null, null);
+            return For<long>(fromInclusive, toExclusive, s_defaultParallelOptions, body);
         }
 
         /// <summary>
@@ -431,11 +424,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> body)
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<int, object>(
-                fromInclusive, toExclusive, parallelOptions,
-                body, null, null, null, null);
+            return For<int>(fromInclusive, toExclusive, parallelOptions, body);
         }
 
         /// <summary>
@@ -467,11 +456,17 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions, Action<long> body)
         {
+            return For<long>(fromInclusive, toExclusive, parallelOptions, body);
+        }
+
+        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive, ParallelOptions parallelOptions, Action<TIndex> body)
+            where TIndex: INumber<TIndex>
+        {
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<long, object>(
-                fromInclusive, toExclusive, parallelOptions,
-                body, null, null, null, null);
+
+            WorkerWithBodyFactory<TIndex> workerFactory = new WorkerWithBodyFactory<TIndex>(body);
+            return ForWorker(fromInclusive, toExclusive, parallelOptions, workerFactory);
         }
 
         /// <summary>
@@ -516,10 +511,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(int fromInclusive, int toExclusive, Action<int, ParallelLoopState> body)
         {
-            ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<int, object>(
-                fromInclusive, toExclusive, s_defaultParallelOptions,
-                null, body, null, null, null);
+            return For<int>(fromInclusive, toExclusive, s_defaultParallelOptions, body);
         }
 
         /// <summary>
@@ -542,10 +534,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(long fromInclusive, long toExclusive, Action<long, ParallelLoopState> body)
         {
-            ArgumentNullException.ThrowIfNull(body);
-            return ForWorker<long, object>(
-                fromInclusive, toExclusive, s_defaultParallelOptions,
-                null, body, null, null, null);
+            return For<long>(fromInclusive, toExclusive, s_defaultParallelOptions, body);
         }
 
         /// <summary>
@@ -579,12 +568,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static ParallelLoopResult For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int, ParallelLoopState> body)
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(body);
-
-            return ForWorker<int, object>(
-                fromInclusive, toExclusive, parallelOptions,
-                null, body, null, null, null);
+            return For<int>(fromInclusive, toExclusive, parallelOptions, body);
         }
 
         /// <summary>
@@ -619,12 +603,17 @@ namespace System.Threading.Tasks
         public static ParallelLoopResult For(long fromInclusive, long toExclusive, ParallelOptions parallelOptions,
             Action<long, ParallelLoopState> body)
         {
+            return For<long>(fromInclusive, toExclusive, parallelOptions, body);
+        }
+
+        private static ParallelLoopResult For<TIndex>(TIndex fromInclusive, TIndex toExclusive, ParallelOptions parallelOptions, Action<TIndex, ParallelLoopState> body)
+            where TIndex: INumber<TIndex>
+        {
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForWorker<long, object>(
-                fromInclusive, toExclusive, parallelOptions,
-                null, body, null, null, null);
+            WorkerWithStateFactory<TIndex> workerFactory = new WorkerWithStateFactory<TIndex>(body);
+            return ForWorker(fromInclusive, toExclusive, parallelOptions, workerFactory);
         }
 
         /// <summary>
@@ -671,13 +660,7 @@ namespace System.Threading.Tasks
             Func<int, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
-
-            return ForWorker(
-                fromInclusive, toExclusive, s_defaultParallelOptions,
-                null, null, body, localInit, localFinally);
+            return For<int, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body, localFinally);
         }
 
         /// <summary>
@@ -724,13 +707,7 @@ namespace System.Threading.Tasks
             Func<long, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
-
-            return ForWorker(
-                fromInclusive, toExclusive, s_defaultParallelOptions,
-                null, null, body, localInit, localFinally);
+            return For<long, TLocal>(fromInclusive, toExclusive, s_defaultParallelOptions, localInit, body, localFinally);
         }
 
         /// <summary>
@@ -788,14 +765,7 @@ namespace System.Threading.Tasks
             Func<int, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
-            ArgumentNullException.ThrowIfNull(parallelOptions);
-            ArgumentNullException.ThrowIfNull(localInit);
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(localFinally);
-
-            return ForWorker(
-                fromInclusive, toExclusive, parallelOptions,
-                null, null, body, localInit, localFinally);
+            return For<int, TLocal>(fromInclusive, toExclusive, parallelOptions, localInit, body, localFinally);
         }
 
         /// <summary>
@@ -853,14 +823,23 @@ namespace System.Threading.Tasks
             Func<long, ParallelLoopState, TLocal, TLocal> body,
             Action<TLocal> localFinally)
         {
+            return For<long, TLocal>(fromInclusive, toExclusive, parallelOptions, localInit, body, localFinally);
+        }
+
+        private static ParallelLoopResult For<TIndex, TLocal>(
+            TIndex fromInclusive, TIndex toExclusive, ParallelOptions parallelOptions,
+            Func<TLocal> localInit,
+            Func<TIndex, ParallelLoopState, TLocal, TLocal> body,
+            Action<TLocal> localFinally)
+            where TIndex: INumber<TIndex>
+        {
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(localInit);
             ArgumentNullException.ThrowIfNull(body);
             ArgumentNullException.ThrowIfNull(localFinally);
 
-            return ForWorker(
-                fromInclusive, toExclusive, parallelOptions,
-                null, null, body, localInit, localFinally);
+            WorkerWithLocalFactory<TIndex, TLocal> workerFactory = new WorkerWithLocalFactory<TIndex, TLocal>(body, localInit, localFinally);
+            return ForWorker(fromInclusive, toExclusive, parallelOptions, workerFactory);
         }
 
         /// <summary>
@@ -872,30 +851,18 @@ namespace System.Threading.Tasks
         ///
         /// </summary>
         /// <typeparam name="TIndex">The type of the index size used (int/long).</typeparam>
-        /// <typeparam name="TLocal">The type of the local data.</typeparam>
         /// <param name="fromInclusive">The loop's start index, inclusive.</param>
         /// <param name="toExclusive">The loop's end index, exclusive.</param>
         /// <param name="parallelOptions">A ParallelOptions instance.</param>
-        /// <param name="body">The simple loop body.</param>
-        /// <param name="bodyWithState">The loop body for ParallelState overloads.</param>
-        /// <param name="bodyWithLocal">The loop body for thread local state overloads.</param>
-        /// <param name="localInit">A selector function that returns new thread local state.</param>
-        /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
+        /// <param name="workerFactory">Factory for creating thread workers</param>
         /// <remarks>Only one of the body arguments may be supplied (i.e. they are exclusive).</remarks>
         /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
-        private static ParallelLoopResult ForWorker<TIndex, TLocal>(
+        private static ParallelLoopResult ForWorker<TIndex>(
             TIndex fromInclusive, TIndex toExclusive,
             ParallelOptions parallelOptions,
-            Action<TIndex>? body,
-            Action<TIndex, ParallelLoopState>? bodyWithState,
-            Func<TIndex, ParallelLoopState, TLocal, TLocal>? bodyWithLocal,
-            Func<TLocal>? localInit, Action<TLocal>? localFinally) where TIndex : INumber<TIndex>
+            IWorkerFactory<TIndex> workerFactory) where TIndex : INumber<TIndex>
         {
             Debug.Assert(typeof(TIndex) == typeof(int) || typeof(TIndex) == typeof(long), "only long and int index types supported in TIndex");
-            Debug.Assert(((body == null ? 0 : 1) + (bodyWithState == null ? 0 : 1) + (bodyWithLocal == null ? 0 : 1)) == 1,
-                "expected exactly one body function to be supplied");
-            Debug.Assert(bodyWithLocal != null || (localInit == null && localFinally == null),
-                "thread local functions should only be supplied for loops w/ thread local bodies");
 
             // Instantiate our result.  Specifics will be filled in later.
             ParallelLoopResult result = default;
@@ -932,10 +899,7 @@ namespace System.Threading.Tasks
             {
                 try
                 {
-                    TaskReplicator.ReplicatableUserAction<RangeWorker> worker = CreateForWorker(
-                        sharedPStateFlags, rangeManager, forkJoinContextID, body, bodyWithState, bodyWithLocal,
-                        localInit, localFinally
-                    );
+                    TaskReplicator.ReplicatableUserAction<RangeWorker> worker = workerFactory.CreateWorker(sharedPStateFlags, rangeManager, forkJoinContextID);
                     TaskReplicator.Run(worker, parallelOptions, stopOnFirstFailure: true);
                 }
                 finally
@@ -977,156 +941,6 @@ namespace System.Threading.Tasks
             }
 
             return result;
-        }
-
-         private static TaskReplicator.ReplicatableUserAction<RangeWorker> CreateForWorker2<TIndex, TLocal>(
-            ParallelLoopStateFlags sharedPStateFlags,
-            RangeManager rangeManager,
-            int forkJoinContextID,
-            Action<TIndex>? body,
-            Action<TIndex, ParallelLoopState>? bodyWithState,
-            Func<TIndex, ParallelLoopState, TLocal, TLocal>? bodyWithLocal,
-            Func<TLocal>? localInit,
-            Action<TLocal>? localFinally) where TIndex : INumber<TIndex>
-        {
-            return (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
-            {
-                // First thing we do upon entering the task is to register as a new "RangeWorker" with the
-                // shared RangeManager instance.
-                if (!currentWorker.IsInitialized)
-                    currentWorker = rangeManager.RegisterNewWorker();
-
-                // We will need to reset this to true if we exit due to a timeout:
-                replicationDelegateYieldedBeforeCompletion = false;
-
-                // We need to call FindNewWork() on it to see whether there's a chunk available.
-                // These are the local index values to be used in the sequential loop.
-                // Their values filled in by FindNewWork
-                if (currentWorker.FindNewWork(out TIndex nFromInclusiveLocal, out TIndex nToExclusiveLocal) == false ||
-                    sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal))
-                {
-                    return; // no need to run
-                }
-
-                LogEtwEventParallelFork(forkJoinContextID);
-
-                TLocal localValue = default!;
-                bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
-
-                try
-                {
-                    // Create a new state object that references the shared "stopped" and "exceptional" flags
-                    // If needed, it will contain a new instance of thread-local state by invoking the selector.
-                    ParallelLoopState? state = null;
-
-                    if (bodyWithState != null || bodyWithLocal != null)
-                    {
-                        state = ParallelLoopState.Create<TIndex>(sharedPStateFlags);
-                    }
-
-                    // If a thread-local selector was supplied, invoke it. Otherwise, use the default.
-                    if (localInit != null)
-                    {
-                        localValue = localInit();
-                        bLocalValueInitialized = true;
-                    }
-
-                    // initialize a loop timer which will help us decide whether we should exit early
-                    int loopTimeout = ComputeTimeoutPoint(timeout);
-
-                    // Now perform the loop itself.
-                    do
-                    {
-                        if (body != null)
-                        {
-                            for (TIndex j = nFromInclusiveLocal;
-                                 j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone // fast path check as SEL() doesn't inline
-                                                           || !sharedPStateFlags.ShouldExitLoop()); // the no-arg version is used since we have no state
-                                 j += TIndex.One)
-                            {
-                                body(j);
-                            }
-                        }
-                        else if (bodyWithState != null)
-                        {
-                            for (TIndex j = nFromInclusiveLocal;
-                                 j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone // fast path check as SEL() doesn't inline
-                                                           || !sharedPStateFlags.ShouldExitLoop(j));
-                                 j += TIndex.One)
-                            {
-                                state!.SetCurrentIteration(j);
-                                bodyWithState(j, state);
-                            }
-                        }
-                        else
-                        {
-                            for (TIndex j = nFromInclusiveLocal;
-                                 j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone // fast path check as SEL() doesn't inline
-                                                           || !sharedPStateFlags.ShouldExitLoop(j));
-                                 j += TIndex.One)
-                            {
-                                state!.SetCurrentIteration(j);
-                                localValue = bodyWithLocal!(j, state, localValue);
-                            }
-                        }
-
-                        // Cooperative multitasking:
-                        // Check if allowed loop time is exceeded, if so save current state and return.
-                        // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
-                        if (CheckTimeoutReached(loopTimeout))
-                        {
-                            replicationDelegateYieldedBeforeCompletion = true;
-                            break;
-                        }
-                        // Exit DO-loop if we can't find new work, or if the loop was stopped:
-                    } while (currentWorker.FindNewWork(out nFromInclusiveLocal, out nToExclusiveLocal) &&
-                             ((sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone) ||
-                              !sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal)));
-                }
-                catch (Exception ex)
-                {
-                    // if we catch an exception in a worker, we signal the other workers to exit the loop, and we rethrow
-                    sharedPStateFlags.SetExceptional();
-                    ExceptionDispatchInfo.Throw(ex);
-                }
-                finally
-                {
-                    // If a cleanup function was specified, call it. Otherwise, if the type is
-                    // IDisposable, we will invoke Dispose on behalf of the user.
-                    if (localFinally != null && bLocalValueInitialized)
-                    {
-                        localFinally(localValue);
-                    }
-
-                    LogEtwEventParallelJoin(forkJoinContextID);
-                }
-            };
-        }
-
-
-
-        private static TaskReplicator.ReplicatableUserAction<RangeWorker> CreateForWorker<TIndex, TLocal>(
-            ParallelLoopStateFlags sharedPStateFlags,
-            RangeManager rangeManager,
-            int forkJoinContextId,
-            Action<TIndex>? body,
-            Action<TIndex, ParallelLoopState>? bodyWithState,
-            Func<TIndex, ParallelLoopState, TLocal, TLocal>? bodyWithLocal,
-            Func<TLocal>? localInit,
-            Action<TLocal>? localFinally) where TIndex : INumber<TIndex>
-        {
-            if (body != null)
-            {
-                return new WorkerWithBody<TIndex>(rangeManager, sharedPStateFlags, forkJoinContextId, body).Work;
-            }
-            if (bodyWithState != null)
-            {
-                return new WorkerWithState<TIndex>(rangeManager, sharedPStateFlags, forkJoinContextId, bodyWithState).Work;
-            }
-
-            Debug.Assert(bodyWithLocal != null && localInit != null,
-                "We expect body with local and local init to be non null in this branch");
-            return new WorkerWithLocal<TIndex, TLocal>(rangeManager, sharedPStateFlags, forkJoinContextId, bodyWithLocal!, localInit!, localFinally).Work;
         }
 
         private abstract class Worker<TIndex> where TIndex : INumber<TIndex>
@@ -1213,7 +1027,7 @@ namespace System.Threading.Tasks
         {
             private readonly Action<TIndex> _body;
 
-            public WorkerWithBody(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId, Action<TIndex> body) : base(rangeManager, sharedPStateFlags, forkJoinContextId)
+            private WorkerWithBody(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId, Action<TIndex> body) : base(rangeManager, sharedPStateFlags, forkJoinContextId)
             {
                 _body = body;
             }
@@ -1228,6 +1042,11 @@ namespace System.Threading.Tasks
                     _body(j);
                 }
             }
+
+            internal static TaskReplicator.ReplicatableUserAction<RangeWorker> Create(ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager, int forkJoinContextId, Action<TIndex> body) =>
+                (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion)
+                    => new WorkerWithBody<TIndex>(rangeManager, sharedPStateFlags, forkJoinContextId, body)
+                        .Work(ref currentWorker, timeout, out replicationDelegateYieldedBeforeCompletion);
         }
 
         private sealed class WorkerWithState<TIndex> : Worker<TIndex> where TIndex : INumber<TIndex>
@@ -1235,7 +1054,7 @@ namespace System.Threading.Tasks
             private readonly Action<TIndex, ParallelLoopState> _bodyWithState;
             private readonly ParallelLoopState _state;
 
-            public WorkerWithState(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId, Action<TIndex, ParallelLoopState> bodyWithState) : base(rangeManager, sharedPStateFlags, forkJoinContextId)
+            private WorkerWithState(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId, Action<TIndex, ParallelLoopState> bodyWithState) : base(rangeManager, sharedPStateFlags, forkJoinContextId)
             {
                 _bodyWithState = bodyWithState;
                 _state = ParallelLoopState.Create<TIndex>(sharedPStateFlags);
@@ -1252,6 +1071,11 @@ namespace System.Threading.Tasks
                     _bodyWithState(j, _state);
                 }
             }
+
+            internal static TaskReplicator.ReplicatableUserAction<RangeWorker> Create(ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager, int forkJoinContextId, Action<TIndex, ParallelLoopState> bodyWithState) =>
+                (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion)
+                    => new WorkerWithState<TIndex>(rangeManager, sharedPStateFlags, forkJoinContextId, bodyWithState)
+                        .Work(ref currentWorker, timeout, out replicationDelegateYieldedBeforeCompletion);
         }
 
         private sealed class WorkerWithLocal<TIndex, TLocal> : Worker<TIndex> where TIndex : INumber<TIndex>
@@ -1261,7 +1085,7 @@ namespace System.Threading.Tasks
             private readonly ParallelLoopState _state;
             private TLocal _localValue;
 
-            public WorkerWithLocal(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId,
+            private WorkerWithLocal(RangeManager rangeManager, ParallelLoopStateFlags sharedPStateFlags, int forkJoinContextId,
                 Func<TIndex, ParallelLoopState, TLocal, TLocal> bodyWithLocal, Func<TLocal> localInit, Action<TLocal>? localFinally)
                 : base(rangeManager, sharedPStateFlags, forkJoinContextId)
             {
@@ -1289,6 +1113,65 @@ namespace System.Threading.Tasks
                 // IDisposable, we will invoke Dispose on behalf of the user.
                 _localFinally?.Invoke(_localValue);
             }
+
+            internal static TaskReplicator.ReplicatableUserAction<RangeWorker> Create(ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager, int forkJoinContextId, Func<TIndex, ParallelLoopState, TLocal, TLocal> bodyWithLocal, Func<TLocal> localInit, Action<TLocal>? localFinally) =>
+                (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion)
+                    => new WorkerWithLocal<TIndex, TLocal>(rangeManager, sharedPStateFlags, forkJoinContextId, bodyWithLocal!, localInit!, localFinally)
+                        .Work(ref currentWorker, timeout, out replicationDelegateYieldedBeforeCompletion);
+        }
+
+        private interface IWorkerFactory<TIndex> where TIndex : INumber<TIndex>
+        {
+            TaskReplicator.ReplicatableUserAction<RangeWorker> CreateWorker(ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager, int forkJoinContextId);
+        }
+
+        private sealed class WorkerWithBodyFactory<TIndex> : IWorkerFactory<TIndex> where TIndex : INumber<TIndex>
+        {
+            private readonly Action<TIndex> _body;
+
+            public WorkerWithBodyFactory(Action<TIndex> body)
+            {
+                _body = body;
+            }
+
+            public TaskReplicator.ReplicatableUserAction<RangeWorker> CreateWorker(
+                ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager,
+                int forkJoinContextId) =>
+                WorkerWithBody<TIndex>.Create(sharedPStateFlags, rangeManager, forkJoinContextId, _body);
+        }
+
+        private sealed class WorkerWithStateFactory<TIndex> : IWorkerFactory<TIndex> where TIndex : INumber<TIndex>
+        {
+            private readonly Action<TIndex, ParallelLoopState> _bodyWithState;
+
+            public WorkerWithStateFactory(Action<TIndex, ParallelLoopState> bodyWithState)
+            {
+                _bodyWithState = bodyWithState;
+            }
+
+            public TaskReplicator.ReplicatableUserAction<RangeWorker> CreateWorker(
+                ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager,
+                int forkJoinContextId) =>
+                WorkerWithState<TIndex>.Create(sharedPStateFlags, rangeManager, forkJoinContextId, _bodyWithState);
+        }
+
+        private sealed class WorkerWithLocalFactory<TIndex, TLocal> : IWorkerFactory<TIndex> where TIndex : INumber<TIndex>
+        {
+            private readonly Func<TIndex, ParallelLoopState, TLocal, TLocal> _bodyWithLocal;
+            private readonly Func<TLocal> _localInit;
+            private readonly Action<TLocal>? _localFinally;
+
+            public WorkerWithLocalFactory(Func<TIndex, ParallelLoopState, TLocal, TLocal> bodyWithLocal, Func<TLocal> localInit, Action<TLocal>? localFinally)
+            {
+                _bodyWithLocal = bodyWithLocal;
+                _localInit = localInit;
+                _localFinally = localFinally;
+            }
+
+            public TaskReplicator.ReplicatableUserAction<RangeWorker> CreateWorker(
+                ParallelLoopStateFlags sharedPStateFlags, RangeManager rangeManager,
+                int forkJoinContextId) =>
+                WorkerWithLocal<TIndex, TLocal>.Create(sharedPStateFlags, rangeManager, forkJoinContextId, _bodyWithLocal, _localInit, _localFinally);
         }
 
         /// <summary>
@@ -1837,32 +1720,34 @@ namespace System.Threading.Tasks
 
             int from = array.GetLowerBound(0);
             int to = array.GetUpperBound(0) + 1;
-            Action<int>? newBody = null;
-            Action<int, ParallelLoopState>? newBodyWithState = null;
-            Func<int, ParallelLoopState, TLocal, TLocal>? newBodyWithLocal = null;
 
+            IWorkerFactory<long> workerFactory;
             if (body is not null)
             {
-                newBody = (i) => body(array[i]);
+                workerFactory = new WorkerWithBodyFactory<long>((i) => body(array[i]));
             }
             else if (bodyWithState is not null)
             {
-                newBodyWithState = (i, state) => bodyWithState(array[i], state);
+                workerFactory = new WorkerWithStateFactory<long>((i, state) => bodyWithState(array[i], state));
             }
             else if (bodyWithStateAndIndex is not null)
             {
-                newBodyWithState = (i, state) => bodyWithStateAndIndex(array[i], state, i);
+                workerFactory = new WorkerWithStateFactory<long>((i, state) => bodyWithStateAndIndex(array[i], state, i));
             }
             else if (bodyWithStateAndLocal is not null)
             {
-                newBodyWithLocal = (i, state, local) => bodyWithStateAndLocal(array[i], state, local);
+                workerFactory = new WorkerWithLocalFactory<long, TLocal>(
+                    (i, state, local) => bodyWithStateAndLocal(array[i], state, local), localInit!, localFinally
+                );
             }
             else
             {
-                newBodyWithLocal = (i, state, local) => bodyWithEverything!(array[i], state, i, local);
+                workerFactory = new WorkerWithLocalFactory<long, TLocal>(
+                    (i, state, local) => bodyWithEverything!(array[i], state, i, local), localInit!, localFinally
+                );
             }
 
-            return ForWorker(from, to, parallelOptions, newBody, newBodyWithState, newBodyWithLocal, localInit, localFinally);
+            return ForWorker(from, to, parallelOptions, workerFactory);
         }
 
         /// <summary>
@@ -1897,32 +1782,33 @@ namespace System.Threading.Tasks
             int from = 0;
             int to = list.Count;
 
-            Action<int>? newBody = null;
-            Action<int, ParallelLoopState>? newBodyWithState = null;
-            Func<int, ParallelLoopState, TLocal, TLocal>? newBodyWithLocal = null;
-
+            IWorkerFactory<int> workerFactory;
             if (body is not null)
             {
-                newBody = (i) => body(list[i]);
+                workerFactory = new WorkerWithBodyFactory<int>((i) => body(list[i]));
             }
             else if (bodyWithState is not null)
             {
-                newBodyWithState = (i, state) => bodyWithState(list[i], state);
+                workerFactory = new WorkerWithStateFactory<int>((i, state) => bodyWithState(list[i], state));
             }
             else if (bodyWithStateAndIndex is not null)
             {
-                newBodyWithState = (i, state) => bodyWithStateAndIndex(list[i], state, i);
+                workerFactory = new WorkerWithStateFactory<int>((i, state) => bodyWithStateAndIndex(list[i], state, i));
             }
             else if (bodyWithStateAndLocal is not null)
             {
-                newBodyWithLocal = (i, state, local) => bodyWithStateAndLocal(list[i], state, local);
+                workerFactory = new WorkerWithLocalFactory<int, TLocal>(
+                    (i, state, local) => bodyWithStateAndLocal(list[i], state, local), localInit!, localFinally
+                );
             }
             else
             {
-                newBodyWithLocal = (i, state, local) => bodyWithEverything!(list[i], state, i, local);
+                workerFactory = new WorkerWithLocalFactory<int, TLocal>(
+                    (i, state, local) => bodyWithEverything!(list[i], state, i, local), localInit!, localFinally
+                );
             }
 
-            return ForWorker(from, to, parallelOptions, newBody, newBodyWithState, newBodyWithLocal, localInit, localFinally);
+            return ForWorker(from, to, parallelOptions, workerFactory);
         }
 
 

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -590,7 +590,7 @@ namespace System.Threading.Tasks
             // For all loops we need a shared flag even though we don't have a body with state,
             // because the shared flag contains the exceptional bool, which triggers other workers
             // to exit their loops if one worker catches an exception
-            ParallelLoopStateFlags sharedPStateFlags = ParallelLoopStateFlags.Create<long>();
+            ParallelLoopStateFlags sharedPStateFlags = ParallelLoopStateFlags.Create<TIndex>();
 
             // Before getting started, do a quick peek to see if we have been canceled already
             parallelOptions.CancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
@@ -263,6 +263,8 @@ namespace System.Threading.Tasks
         }
 
         //Can't Turn the class to abstract so added as virtual
+        internal virtual TIndex GetCurrentIteration<TIndex>()
+            where TIndex : INumber<TIndex> => throw new NotImplementedException("Should not call this");
         internal virtual void SetCurrentIteration<TIndex>(TIndex CurrentIteration)
             where TIndex : INumber<TIndex> => throw new NotImplementedException("Should not call this");
     }
@@ -328,6 +330,7 @@ namespace System.Threading.Tasks
         }
 
         internal override void SetCurrentIteration<TIndex>(TIndex currentIteration) => CurrentIteration = int.CreateChecked(currentIteration);
+        internal override TIndex GetCurrentIteration<TIndex>() => TIndex.CreateChecked(CurrentIteration);
     }
 
     /// <summary>
@@ -398,6 +401,8 @@ namespace System.Threading.Tasks
         }
 
         internal override void SetCurrentIteration<TIndex>(TIndex currentIteration) => CurrentIteration = long.CreateChecked(currentIteration);
+        internal override TIndex GetCurrentIteration<TIndex>() => TIndex.CreateChecked(CurrentIteration);
+
     }
 
     /// <summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
@@ -77,7 +77,7 @@ namespace System.Threading.Tasks
 
             _nIncrementValue = nStep;
 
-            _nMaxIncrementValue = Parallel.DEFAULT_LOOP_STRIDE * nStep;
+            _nMaxIncrementValue = Parallel.DefaultLoopStride * nStep;
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
@@ -77,7 +77,7 @@ namespace System.Threading.Tasks
 
             _nIncrementValue = nStep;
 
-            _nMaxIncrementValue = Parallel.DefaultLoopStride * nStep;
+            _nMaxIncrementValue = Parallel.DEFAULT_LOOP_STRIDE * nStep;
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
@@ -229,11 +229,17 @@ namespace System.Threading.Tasks
         internal int _nCurrentIndexRangeToAssign;
         internal long _nStep;
 
+        internal long FromInclusive { get;  }
+        internal long ToExclusive { get;  }
+
         /// <summary>
         /// Initializes a RangeManager with the given loop parameters, and the desired number of outer ranges
         /// </summary>
         internal RangeManager(long nFromInclusive, long nToExclusive, long nStep, int nNumExpectedWorkers)
         {
+            FromInclusive = nFromInclusive;
+            ToExclusive = nToExclusive;
+
             _nCurrentIndexRangeToAssign = 0;
             _nStep = nStep;
 


### PR DESCRIPTION
PR for Issue: [issue](https://github.com/dotnet/runtime/issues/53593)
* Created Worker object for each of the 3 implementations of the For Worker: body, state, and local. 
* Created WorkerFactory for creating the replicable tasks 
